### PR TITLE
Increase QSPI flash frequency

### DIFF
--- a/target/sama5d2/board_sama5d2-xplained.h
+++ b/target/sama5d2/board_sama5d2-xplained.h
@@ -266,7 +266,7 @@
 
 #define QSPIFLASH_PINS     PINS_QSPI0_IOS3
 #define QSPIFLASH_ADDR     QSPI0
-#define QSPIFLASH_BAUDRATE 50000000 /* 50 MHz */
+#define QSPIFLASH_BAUDRATE 100000000 /* 50 MHz */
 
 /* =================== CAN device definition ==================== */
 /* Both ports are wired to the J9 connector:

--- a/target/sama5d2/chip_pins.h
+++ b/target/sama5d2/chip_pins.h
@@ -856,7 +856,7 @@
 
 /* QSPI0 IOSET 3 */
 #define PINS_QSPI0_IOS3 {\
-	{ PIO_GROUP_A, 0x0fc00000, PIO_PERIPH_F, PIO_PULLUP },\
+	{ PIO_GROUP_A, 0x0fc00000, PIO_PERIPH_F, PIO_PULLUP | PIO_DRVSTR_HI },\
 }
 
 /* ========== Pio PIN definition for QSPI1 peripheral ========== */


### PR DESCRIPTION
It is possible to use at least 83.1MHz frequency on sama5d2-xplained with appropriate drive strength.
Measured CLK rise/fall times are: 1.30ns/1.18ns.
