### PR TITLE
drivers/dma: Enable/disable mask supports only first 8 channels

### DIFF
--- a/drivers/dma/xdmac.c
+++ b/drivers/dma/xdmac.c
@@ -97,7 +97,7 @@ void xdmac_enable_channel(Xdmac *xdmac, uint8_t channel)
 	xdmac->XDMAC_GE |= XDMAC_GE_EN0 << channel;
 }
 
-void xdmac_enable_channels(Xdmac *xdmac, uint8_t channel_mask)
+void xdmac_enable_channels(Xdmac *xdmac, uint32_t channel_mask)
 {
 	xdmac->XDMAC_GE = channel_mask;
 }
@@ -116,7 +116,7 @@ void xdmac_suspend_channel(Xdmac *xdmac, uint8_t channel)
 	xdmac->XDMAC_GRWS = XDMAC_GRWS_RWS0 << channel;
 }
 
-void xdmac_disable_channels(Xdmac *xdmac, uint8_t channel_mask)
+void xdmac_disable_channels(Xdmac *xdmac, uint32_t channel_mask)
 {
 	xdmac->XDMAC_GD = channel_mask;
 }

--- a/drivers/dma/xdmac.h
+++ b/drivers/dma/xdmac.h
@@ -189,7 +189,7 @@ extern void xdmac_enable_channel(Xdmac *xdmac, uint8_t channel);
  * \param xdmac Pointer to the XDMAC instance.
  * \param channel_mask Channels bitmap.
  */
-extern void xdmac_enable_channels(Xdmac *xdmac, uint8_t channel_mask);
+extern void xdmac_enable_channels(Xdmac *xdmac, uint32_t channel_mask);
 
 /**
  * \brief Disables the relevant channel of given XDMAC.
@@ -213,7 +213,7 @@ extern void xdmac_suspend_channel(Xdmac *xdmac, uint8_t channel);
  * \param xdmac Pointer to the XDMAC instance.
  * \param channel_mask Channels bitmap.
  */
-extern void xdmac_disable_channels(Xdmac *xdmac, uint8_t channel_mask);
+extern void xdmac_disable_channels(Xdmac *xdmac, uint32_t channel_mask);
 
 /**
  * \brief Get Global channel status of given XDMAC.


### PR DESCRIPTION
It looks like xdmac_enable_channels and xdmac_disable_channels support only half of DMA channels.