### PR TITLE
samba_applets/sdmmc/main: Fix bug for >4G eMMC

### DIFF
--- a/samba_applets/sdmmc/main.c
+++ b/samba_applets/sdmmc/main.c
@@ -401,7 +401,7 @@ static uint32_t handle_cmd_initialize(uint32_t cmd, uint32_t *mailbox)
 		                              EMMC_BOOT_ACK);
 		mmc_configure_boot_bus(&lib, 0);
 	} else {
-		mem_size = SD_GetTotalSizeKB(&lib) * 1024 / BLOCK_SIZE;
+		mem_size = (uint32_t)(((uint64_t)SD_GetTotalSizeKB(&lib) * 1024ull) / BLOCK_SIZE);
 	}
 
 	buffer = applet_buffer;


### PR DESCRIPTION
The operation here attempts to convert a value in KB into bytes,
however, all operands are uint32_t types, so the operation will
overflow.  Widen the type for the operation and narrow only when the
final mem_size is set.