### PR TITLE
Fix bug with 256-page i2c memory

### DIFF
--- a/drivers/nvm/i2c/at24.c
+++ b/drivers/nvm/i2c/at24.c
@@ -217,6 +217,7 @@ int at24_read(const struct _at24* at24, uint32_t offset, uint8_t* data, uint16_t
 int at24_write(const struct _at24* at24, uint32_t offset, const uint8_t* data, uint16_t length)
 {
 	const uint8_t page_size = at24->desc->page_size;
+	const uint16_t page_size = at24->desc->page_size;
 	uint8_t addr_offset, addr_buf[2];
 	struct _buffer buf[2] = {
 		{
@@ -231,6 +232,7 @@ int at24_write(const struct _at24* at24, uint32_t offset, const uint8_t* data, u
 		},
 	};
 	uint8_t chunk_size;
+	uint16_t chunk_size;
 	int err = 0;
 
 	/* start a TWI bus transaction */

--- a/drivers/nvm/i2c/at24.c
+++ b/drivers/nvm/i2c/at24.c
@@ -96,6 +96,7 @@ static const struct _at24_desc _at24_devices[] = {
 	{ MCP24AA02E64,  "MCP24AA02",  MCP24AAE6,  7,   8, .eui = { MCP24AA_EUI64_ADDR_OFFSET, MCP24AA_EUI64_OFFSET, EUI64_LENGTH }, },
 	{ MCP24AA025E48, "MCP24AA025", MCP24AAE4,  7,  16, .eui = { MCP24AA_EUI48_ADDR_OFFSET, MCP24AA_EUI48_OFFSET, EUI48_LENGTH }, },
 	{ MCP24AA025E64, "MCP24AA025", MCP24AAE6,  7,  16, .eui = { MCP24AA_EUI64_ADDR_OFFSET, MCP24AA_EUI64_OFFSET, EUI64_LENGTH }, },
+        { FM24V10,       "FM24V10",    FM24V,     17, 256, },
 };
 
 /*------------------------------------------------------------------------------
@@ -216,7 +217,6 @@ int at24_read(const struct _at24* at24, uint32_t offset, uint8_t* data, uint16_t
 
 int at24_write(const struct _at24* at24, uint32_t offset, const uint8_t* data, uint16_t length)
 {
-	const uint8_t page_size = at24->desc->page_size;
 	const uint16_t page_size = at24->desc->page_size;
 	uint8_t addr_offset, addr_buf[2];
 	struct _buffer buf[2] = {
@@ -231,7 +231,6 @@ int at24_write(const struct _at24* at24, uint32_t offset, const uint8_t* data, u
 			.attr = BUS_BUF_ATTR_TX | BUS_I2C_BUF_ATTR_STOP,
 		},
 	};
-	uint8_t chunk_size;
 	uint16_t chunk_size;
 	int err = 0;
 

--- a/drivers/nvm/i2c/at24.h
+++ b/drivers/nvm/i2c/at24.h
@@ -70,6 +70,7 @@ enum _at24_model {
 	MCP24AA02E64,
 	MCP24AA025E48,
 	MCP24AA025E64,
+        FM24V10,
 };
 
 enum _at24_family {
@@ -79,6 +80,7 @@ enum _at24_family {
 	AT24MAC6,
 	MCP24AAE4,
 	MCP24AAE6,
+        FM24V,
 };
 
 struct _at24_desc {


### PR DESCRIPTION
In function *at24_write()*:
type of **page_size** and **chunk_size** changed from uint8_t to uint16_t. The new type is selected according to the type **at24->desc->page_size**. If page size of device was 256, then the variables in the function became zero.

Also add support of F-RAM Cypress FM24V10 