### PR TITLE
target/samv71: lower the PLLA multiplier

### DIFF
--- a/target/samv71/board_support.c
+++ b/target/samv71/board_support.c
@@ -96,7 +96,7 @@ const char* get_board_name(void)
 void board_cfg_clocks(void)
 {
 	struct _pmc_plla_cfg plla_config = {
-		.mul = 49,
+		.mul = 24,
 		.div = 1,
 		.count = 0x3f,
 	};
@@ -105,7 +105,7 @@ void board_cfg_clocks(void)
 	pmc_disable_plla();
 	pmc_select_external_osc(false);
 	pmc_configure_plla(&plla_config);
-	pmc_set_mck_prescaler(PMC_MCKR_PRES_CLOCK_DIV2);
+	pmc_set_mck_prescaler(PMC_MCKR_PRES_CLOCK);
 	pmc_set_mck_divider(PMC_MCKR_MDIV_PCK_DIV2);
 	pmc_switch_mck_to_pll();
 }


### PR DESCRIPTION
This will lower the PLLA Clock (PLLACK) to (24+1)_12=300MHz
instead of (49+1)_12=600MHz. Also change the PMC_MCKR prescaler
to 1 instead of 2 which will result in the same HCLK and MCK
as before this change.

This will save about 6mA during idle and also bring the
PLLACK within specification (max is 500MHz according to
Table 58-26, page 2055 in datasheet DS60001527B).