### PR TITLE
drivers/irq: add code to force int vectors to 0 for sama5 chips

### DIFF
--- a/drivers/irq/irq.c
+++ b/drivers/irq/irq.c
@@ -131,6 +131,18 @@ static void _default_irq_handler(void)
 
 void irq_initialize(void)
 {
+
+#ifdef CONFIG_ARCH_ARMV7A
+	/*
+	 * This ensures that the interrupt vector table is located at the base of memory (0x00000000).
+	 * U-Boot can relocate this by setting the VBAR register. This ensures that the code is resilient
+	 * to various startup conditions (e.g. through U-Boot).
+	 */
+	uint32_t vbar = 0;
+	/* Set VBAR to 0x00000000 */
+	asm("mcr p15, 0, %0, c12, c0, 0" :: "r"(vbar));
+#endif
+
 	_initialize_handlers_pool();
 
 #if defined(CONFIG_HAVE_AIC2) || defined(CONFIG_HAVE_AIC5)


### PR DESCRIPTION
I was having issues running DDR targeted examples when booting through U-Boot. I raised #96 and following support from @TonyHan11, I discovered that the U-Boot application was relocating the interrupt vector table to an alternate address from the default (0x00000000) prior to vectoring to the start of the example applications. This pull request simply adds a line of assembler to the irq_initialize() routine that ensures that the interrupts vector to addresses offset from 0x00000000 by setting the VBAR register.
I have tested this on the SAMA5D3-Xplained dev board only.

Signed-off-by PaulMadle <pmadle@kispe.co.uk>