### PR TITLE
Fix SPI write slowness

### DIFF
--- a/drivers/nvm/spi-nor/spi-flash.c
+++ b/drivers/nvm/spi-nor/spi-flash.c
@@ -91,8 +91,8 @@ static int spi_flash_is_ready(struct spi_flash *flash)
 
 int spi_flash_wait_till_ready_timeout(struct spi_flash *flash, unsigned long timeout)
 {
-	unsigned long delay = 1L; /* 1ms */
-	unsigned long loop = (timeout + delay - 1) / (delay);
+	unsigned long delay = 1L; /* 1us */
+	unsigned long loop = (timeout * 1000 + delay - 1) / delay;
 	int rc;
 
 	if (!loop)
@@ -104,7 +104,7 @@ int spi_flash_wait_till_ready_timeout(struct spi_flash *flash, unsigned long tim
 		if (rc)
 			return 0;
 
-		msleep(delay);
+		usleep(delay);
 	}
 
 	return -ETIMEDOUT;


### PR DESCRIPTION
When writing SPI flash pages the status bit check is currently done
only every millisecond. This can sum up to a large overhead when
writing a lot of pages. A typical flash page size is 256 bytes.

This commit changes the status check granularity to 1µs.

Some measurements with two (proprietary) boards:

Erasing and writing ~13MiB:

```
       Original code     With this commit applied
HW 1:  176 seconds       128 seconds
HW 2:  144 seconds        67 seconds
```

Fixes GitHub issue #109.