### PR TITLE
target/sama5dx/toolchain/iar: fix potential crash/exception on startup

### DIFF
--- a/target/sama5d2/toolchain/iar/cstartup.s
+++ b/target/sama5d2/toolchain/iar/cstartup.s
@@ -306,6 +306,11 @@ __iar_program_start:
         ldr     sp, =SFE(CSTACK)
         bic     sp, sp, #0x7
 
+        ; Initialize VFP (if needed)
+
+        FUNCALL __iar_program_start, __iar_init_vfp
+        bl      __iar_init_vfp
+
         ; Execute relocations & zero BSS
 
         FUNCALL __iar_program_start, __iar_data_init3
@@ -319,11 +324,6 @@ __iar_program_start:
 
         FUNCALL __iar_program_start, __iar_init_core
         bl      __iar_init_core
-
-        ; Initialize VFP (if needed)
-
-        FUNCALL __iar_program_start, __iar_init_vfp
-        bl      __iar_init_vfp
 
         ; Perform board initialization
 

--- a/target/sama5d3/toolchain/iar/cstartup.s
+++ b/target/sama5d3/toolchain/iar/cstartup.s
@@ -255,6 +255,11 @@ __iar_program_start:
         ldr     sp, =SFE(CSTACK)
         bic     sp, sp, #0x7
 
+        ; Initialize VFP (if needed)
+
+        FUNCALL __iar_program_start, __iar_init_vfp
+        bl      __iar_init_vfp
+
         ; Execute relocations & zero BSS
 
         FUNCALL __iar_program_start, __iar_data_init3
@@ -268,11 +273,6 @@ __iar_program_start:
 
         FUNCALL __iar_program_start, __iar_init_core
         bl      __iar_init_core
-
-        ; Initialize VFP (if needed)
-
-        FUNCALL __iar_program_start, __iar_init_vfp
-        bl      __iar_init_vfp
 
         ; Perform board initialization
 

--- a/target/sama5d4/toolchain/iar/cstartup.s
+++ b/target/sama5d4/toolchain/iar/cstartup.s
@@ -296,6 +296,11 @@ __iar_program_start:
         ldr     sp, =SFE(CSTACK)
         bic     sp, sp, #0x7
 
+        ; Initialize VFP (if needed)
+
+        FUNCALL __iar_program_start, __iar_init_vfp
+        bl      __iar_init_vfp
+
         ; Execute relocations & zero BSS
 
         FUNCALL __iar_program_start, __iar_data_init3
@@ -309,11 +314,6 @@ __iar_program_start:
 
         FUNCALL __iar_program_start, __iar_init_core
         bl      __iar_init_core
-
-        ; Initialize VFP (if needed)
-
-        FUNCALL __iar_program_start, __iar_init_vfp
-        bl      __iar_init_vfp
 
         ; Perform board initialization
 


### PR DESCRIPTION
If the IAR compiler decodes to use FPU registers for initialization code in __iar_data_init3, then there will be a crash/exception when any FPU register is accessed before __iar_vfp_init is called.

[example: std::unordered_map and some other C++ STL container constructors for some reason might be compiled to use the FPU Sx registers while constructing a static/non-heap-allocated object on startup]

The easy workaround is to change the startup sequence in cstartup.s and move __iar_init_vfp above __iar_data_init3