### PR TITLE
Fix SAMA5D3 disable_ddr in common.gdb

### DIFF
--- a/target/sama5d3/toolchain/gnu/common.gdb
+++ b/target/sama5d3/toolchain/gnu/common.gdb
@@ -24,7 +24,7 @@ end
 # to avoid corrupted RAM data on soft reset.
 define disable_ddr
   set *0xFFFFFC04 = 0x4
-  set *0xFFFFFC14 = (1 << 16)
+  set *0xFFFFFD04 = (1 << 17)
 end
 
 define reset_registers


### PR DESCRIPTION
Fixed GDB debug script for SAMA5D3. Incorrect peripheral ID disabled for MPDDRC controller.

**Previous:**
0xFFFFFC14 = (1 << 16)
Sets the disable Peripheral ID for UART0 in PMC_PCDR0

**Change:**
0xFFFFFD04 = (1 << 17)
Sets the disable Peripheral ID for MPDDR Controller in PMC_PCDR1

See _**Table 8-1. Peripheral Identifiers**_ and register definitions for **_26.17.5 PMC Peripheral Clock Disable Register 0_** and **_26.17.24 PMC Peripheral Clock Disable Register 1_**